### PR TITLE
Feature 145 add MQTT simulator to Docker compose 

### DIFF
--- a/Source Code/Back-End/Docker/docker-compose.yml
+++ b/Source Code/Back-End/Docker/docker-compose.yml
@@ -1,20 +1,43 @@
-version: '3'
 services:
-  mosquitto:
-    image: eclipse-mosquitto:2.0.20
-
   influxdb:
     image: influxdb:2.7
     container_name: influxdb
     ports:
       - "8086:8086"
     volumes:
-      - influxdb-data:/var/lib/influxdb2  # Persisting the data locally
+      - influxdb-data:/var/lib/influxdb2  # Persist data locally
     environment:
       - DOCKER_INFLUXDB_INIT_MODE=setup
-      - DOCKER_INFLUXDB_INIT_USERNAME=admin  # You set this value
-      - DOCKER_INFLUXDB_INIT_PASSWORD=thu.1234  # You set this value
-      - DOCKER_INFLUXDB_INIT_ORG=thu-de  # You set this value
-      - DOCKER_INFLUXDB_INIT_BUCKET=my-bucket  # You set this value
+      - DOCKER_INFLUXDB_INIT_USERNAME=admin
+      - DOCKER_INFLUXDB_INIT_PASSWORD=thu.1234
+      - DOCKER_INFLUXDB_INIT_ORG=thu-de
+      - DOCKER_INFLUXDB_INIT_BUCKET=SmartPacifier-Bucket1
+      - DOCKER_INFLUXDB_INIT_RETENTION=365d  
+    restart: unless-stopped  # Ensuring container restarts on failure
+
+  mosquitto:
+    image: eclipse-mosquitto:2.0
+    container_name: mosquitto
+    ports:
+      - "1883:1883"       # MQTT port
+      - "9001:9001"       # WebSocket port (optional, if needed)
+    volumes:
+      - mosquitto-data:/mosquitto/data
+      - mosquitto-log:/mosquitto/log
+      - ./mosquitto.conf:/mosquitto/config/mosquitto.conf  # Use relative path to the conf file
+    restart: unless-stopped  # Ensuring container restarts on failure
+    environment:
+      - MQTT_ALLOW_ANONYMOUS=true  # Allow anonymous connections (optional)
+    
+  mqttsimulator:
+    image: strivi01/mqttsim:0.1
+    container_name: mqttSimulator
+    volumes:
+      - ./settings.json:/usr/src/app/config/settings.json
+    depends_on:
+      - mosquitto
+
 volumes:
   influxdb-data:
+  mosquitto-data:
+  mosquitto-log:

--- a/Source Code/Back-End/Docker/mosquitto.conf
+++ b/Source Code/Back-End/Docker/mosquitto.conf
@@ -1,0 +1,2 @@
+listener 1883
+allow_anonymous true

--- a/Source Code/Back-End/Docker/settings.json
+++ b/Source Code/Back-End/Docker/settings.json
@@ -1,0 +1,134 @@
+{
+    "BROKER_URL": "host.docker.internal",
+    "BROKER_PORT": 1883,
+    "TOPICS": [
+        {
+            "TYPE": "multiple",
+            "PREFIX": "lamp",
+            "RANGE_START": 1,
+            "RANGE_END": 2,
+            "TIME_INTERVAL": 1,
+            "DATA": [
+                {
+                    "NAME": "on",
+                    "TYPE": "bool",
+                    "RETAIN_PROBABILITY": 0.85
+                },
+                {
+                    "NAME": "temperature",
+                    "TYPE": "int",
+                    "INITIAL_VALUE": 2750,
+                    "MIN_VALUE": 2700,
+                    "MAX_VALUE": 6500,
+                    "MAX_STEP": 250,
+                    "RETAIN_PROBABILITY": 0.3,
+                    "RESET_PROBABILITY": 0.1,
+                    "INCREASE_PROBABILITY": 0.8,
+                    "RESTART_ON_BOUNDARIES": true
+                }
+            ]
+        },
+        {
+            "TYPE": "single",
+            "PREFIX": "air_quality",
+            "TIME_INTERVAL": 6,
+            "DATA": [
+                {
+                    "NAME": "pollution_particles",
+                    "TYPE": "float",
+                    "MIN_VALUE": 0,
+                    "MAX_VALUE": 1,
+                    "MAX_STEP": 0.15,
+                    "RETAIN_PROBABILITY": 0.9
+                },
+                {
+                    "NAME": "alert",
+                    "TYPE": "bool",
+                    "RETAIN_PROBABILITY": 0.9
+                }
+            ]
+        },
+        {
+            "TYPE": "list",
+            "PREFIX": "temperature",
+            "LIST": ["roof", "basement"],
+            "TIME_INTERVAL": 8,
+            "DATA": [
+                {
+                    "NAME": "temperature",
+                    "TYPE": "float",
+                    "MIN_VALUE": 20,
+                    "MAX_VALUE": 55,
+                    "MAX_STEP": 3,
+                    "RETAIN_PROBABILITY": 0.5,
+                    "INCREASE_PROBABILITY": 0.6
+                }
+            ]
+        },
+        {
+            "TYPE": "single",
+            "PREFIX": "freezer",
+            "TIME_INTERVAL": 6,
+            "DATA": [
+                {
+                    "NAME": "temperature",
+                    "TYPE": "math_expression",
+                    "RETAIN_PROBABILITY": 0.1,
+                    "MATH_EXPRESSION": "2*math.pow(x,2)+1",
+                    "INTERVAL_START": 0,
+                    "INTERVAL_END": 5,
+                    "MIN_DELTA": 0.3,
+                    "MAX_DELTA": 0.5
+                }
+            ]
+        },
+        {
+            "TYPE": "single",
+            "PREFIX": "location",
+            "TIME_INTERVAL": 5,
+            "PAYLOAD_ROOT": {
+                "user_id": "abc123"
+            },
+            "DATA": [
+                {
+                    "NAME": "position",
+                    "TYPE": "raw_values",
+                    "RESTART_ON_END": true,
+                    "VALUES": [
+                        "moving",
+                        "stopped"
+                    ]
+                },
+                {
+                    "NAME": "coordinate",
+                    "TYPE": "raw_values",
+                    "VALUE_DEFAULT": {
+                      "alt": 0
+                    },
+                    "RESTART_ON_END": true,
+                    "VALUES": [
+                        {
+                            "alt": 0.1,
+                            "lat": -121.883682,
+                            "long": 37.354635
+                        },
+                        {
+                            "lat": -121.883352,
+                            "long": 37.354192
+                        },
+                        {
+                            "alt": 0.15,
+                            "lat": -121.884284,
+                            "long": 37.353757
+                        },
+                        {
+                            "alt": 0.22,
+                            "lat": -121.885227,
+                            "long": 37.353324
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
* Created own image for the MQTT simulator
* Added service to Docker compose file that pulls the image
* Updated the other services to better reflect real usage
    * This instance of Influx should "mock" the server, maybe a port change may be ideal to not conflict with the "localhost" influx container
    * Updated the Mosquito services to work, using the existing docker compose, since the Broker will be running on a different machine in the expected usage, thus having it the in the docker compose that is in the UI does not reflect real usage. And should accordingly be removed. @muazzamaqeel  
* The settings file can be exchanged, only thing that needs to stay is  `"BROKER_URL": "host.docker.internal"`

 